### PR TITLE
Support deeply set params for hpal curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
   - "8"
-  - "9"
+  - "10"
   - "node"
 
 after_script: "npm run coveralls"

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ hpal run debug:curl patch /user/42 --hometown "Buenos Aires"
 hpal run debug:curl user-update --id 42 --hometown "Buenos Aires"
 ```
 
+Nested parameters may also be specified.  If the route in the previous example validated payloads of the form `{ user: { hometown } }`, one might use one of the following commands instead,
+```sh
+hpal run debug:curl user-update --id 42 --user-hometown "Buenos Aires"
+
+# or
+
+hpal run debug:curl user-update --id 42 --user '{ "hometown": "Buenos Aires" }'
+```
+
 The `-d` `--data` flag may be used to specify a request payload as a raw string.
 
 The `-H` `--header` flag may be used to specify a request header in the format `header-name: header value`.  This flag may be used multiple times to set multiple headers.

--- a/lib/commands/curl.js
+++ b/lib/commands/curl.js
@@ -49,12 +49,12 @@ module.exports = async (server, args, root, ctx) => {
 
     // Make request and time it
 
-    const paramValues = internals.pick(parameters, Object.keys(paramsInfo));
+    const paramValues = internals.pick(parameters, paramsInfo);
     const queryValues = Object.assign(
         Querystring.parse(baseQuery),
-        internals.pick(parameters, Object.keys(queryInfo)),
+        internals.pick(parameters, queryInfo)
     );
-    const payloadValues = parameters.data || internals.pick(parameters, Object.keys(payloadInfo));
+    const payloadValues = parameters.data || internals.pick(parameters, payloadInfo);
     const headerValues = internals.headersFromArray(parameters.header || []);
     const pathname = internals.setParams(path, paramValues);
     const querystring = Querystring.stringify(queryValues);
@@ -98,10 +98,9 @@ module.exports = async (server, args, root, ctx) => {
     output(''); // Make a little room
     output(display.title(`${method} ${url}`) + ' ' + display.subheader(`(${timingEnd - timingStart}ms)`));
 
-    if (request.payload &&
-        (typeof request.payload !== 'object' || Object.keys(request.payload).length)) {
+    if (request.payload !== null) {
 
-        // Payload exists and is not an empty object
+        // Payload was set as a string or object.  When an object, is never empty because a key must have been set.
 
         output('');
         output(display.header('payload'));
@@ -257,20 +256,61 @@ internals.makeDefinition = (info, input) => {
         type: (items && items.length === 1) ? getBossyType(items[0].type) : getBossyType(type)
     });
 
-    return Object.keys(info).reduce((collect, key) => ({
-        ...collect,
-        [key]: transformItem(info[key], input)
-    }), {});
+    const makeDefinition = (subinfo, path) => {
+
+        return Object.keys(subinfo).reduce((collect, key) => {
+
+            const { children } = subinfo[key];
+            const fullPath = path.concat(key);
+            const fullKey = path.concat(key).join('-');
+
+            return {
+                ...collect,
+                ...(children ? makeDefinition(children, fullPath) : {}),
+                [fullKey]: transformItem(subinfo[key], input)
+            };
+        }, {});
+    };
+
+    return makeDefinition(info, []);
 };
 
-internals.pick = (obj, keys) => {
+internals.pick = (parameters, info) => {
 
-    return keys
-        .filter((key) => typeof obj[key] !== 'undefined')
-        .reduce((collect, key) => ({ ...collect, [key]: obj[key] }), {});
+    const pick = (subinfo, path) => {
+
+        const picked = Object.keys(subinfo).reduce((collect, key) => {
+
+            const { children } = subinfo[key];
+            const value = parameters[path.concat(key).join('-')];
+
+            if (typeof value !== 'undefined') {
+                return {
+                    ...collect,
+                    [key]: value
+                };
+            }
+
+            if (children) {
+                const subpicked = pick(children, path.concat(key));
+                if (typeof subpicked !== 'undefined') {
+                    return {
+                        ...collect,
+                        [key]: subpicked
+                    };
+                }
+            }
+
+            return collect;
+        }, {});
+
+        return Object.keys(picked).length > 0 ? picked : undefined;
+    };
+
+    return pick(info, []);
 };
 
-internals.setParams = (path, params) => {
+internals.setParams = (path, params = {}) => {
 
     return path.replace(/(\/)?\{(.+?)(\?|\*[\d]*)?\}/g, (...args) => {
 

--- a/test/closet/curl/server.js
+++ b/test/closet/curl/server.js
@@ -83,6 +83,32 @@ exports.deployment = async () => {
         },
         {
             method: 'post',
+            path: '/deep-payload',
+            options: {
+                id: 'use-deep-payload',
+                validate: {
+                    payload: {
+                        isOne: Joi.boolean().truthy('true'),
+                        objOne: {
+                            two: Joi.number(),
+                            objTwo: {
+                                isFour: Joi.boolean().truthy('true'),
+                                five: Joi.string()
+                            },
+                            objThree: {
+                                six: Joi.number()
+                            },
+                            objFour: {
+                                seven: Joi.string()
+                            }
+                        }
+                    }
+                },
+                handler: ({ payload }) => payload
+            }
+        },
+        {
+            method: 'post',
             path: '/no-joi-validation/{param?}',
             options: {
                 id: 'use-no-joi-validation',

--- a/test/index.js
+++ b/test/index.js
@@ -307,6 +307,20 @@ describe('hpal-debug', () => {
             expect(ignoreNewlines(normalize(output))).to.equal('{ isOne: true, two: 2 }');
         });
 
+        it('can specify deep payload params as flags.', async () => {
+
+            const { output, err, errorOutput } = await curl([
+                'use-deep-payload',
+                '--isOne',
+                '--objOne-objTwo-isFour',
+                '--objOne-objThree', '{"six":6}'
+            ]);
+
+            expect(err).to.not.exist();
+            expect(errorOutput).to.equal('');
+            expect(ignoreNewlines(normalize(output))).to.equal('{ isOne: true, objOne: { objTwo: { isFour: true }, objThree: { six: 6 } } }');
+        });
+
         it('ignores validation when exists but is not a Joi schema.', async () => {
 
             const { output, err, errorOutput } = await curl(['use-no-joi-validation']);
@@ -435,10 +449,8 @@ describe('hpal-debug', () => {
 
                 request headers
                 ────────────────────────────────────────
-                 user-agent        shot
-                 host              hapipal:0
-                 content-type      application/json
-                 content-length    2
+                 user-agent    shot
+                 host          hapipal:0
 
                 response headers
                 ────────────────────────────────────────
@@ -446,7 +458,6 @@ describe('hpal-debug', () => {
                  cache-control     no-cache
                  content-length    22
                  accept-ranges     bytes
-                 connection        close
 
                 result (200 ok)
                 ────────────────────────────────────────
@@ -466,10 +477,8 @@ describe('hpal-debug', () => {
 
                 request headers
                 ────────────────────────────────────────
-                 user-agent        shot
-                 host              hapipal:0
-                 content-type      application/json
-                 content-length    2
+                 user-agent    shot
+                 host          hapipal:0
 
                 response headers
                 ────────────────────────────────────────
@@ -477,7 +486,6 @@ describe('hpal-debug', () => {
                  cache-control     no-cache
                  content-length    22
                  accept-ranges     bytes
-                 connection        close
 
                 result (200 ok)
                 ────────────────────────────────────────
@@ -514,34 +522,6 @@ describe('hpal-debug', () => {
                 result (200 ok)
                 ────────────────────────────────────────
                 { isOne: true, two: 2 }
-            `);
-        });
-
-        it('can specify verbose mode with -v (with payload empty object).', async () => {
-
-            const { output, err, errorOutput } = await curl(['use-payload', '-v'], { columns: 60 });
-
-            expect(err).to.not.exist();
-            expect(errorOutput).to.equal('');
-            validateVerboseOutput(normalize(output), `
-                post /payload (?ms)
-
-                request headers
-                ────────────────────────────────────────
-                 user-agent        shot
-                 host              hapipal:0
-                 content-type      application/json
-                 content-length    2
-
-                response headers
-                ────────────────────────────────────────
-                 content-type      application/json; charset=utf-8
-                 cache-control     no-cache
-                 content-length    2
-
-                result (200 ok)
-                ────────────────────────────────────────
-                {}
             `);
         });
 
@@ -590,8 +570,6 @@ describe('hpal-debug', () => {
                 ────────────────────────────────────────
                 user-agent: shot
                 host: hapipal:0
-                content-type: application/json
-                content-length: 2
 
                 response headers
                 ────────────────────────────────────────
@@ -599,7 +577,6 @@ describe('hpal-debug', () => {
                 cache-control: no-cache
                 content-length: 22
                 accept-ranges: bytes
-                connection: close
 
                 result (200 ok)
                 ────────────────────────────────────────
@@ -649,17 +626,14 @@ describe('hpal-debug', () => {
 
                 request headers
                 ────────────────────────────────────────
-                 user-agent        shot
-                 host              hapipal:0
-                 content-type      application/json
-                 content-length    2
+                 user-agent    shot
+                 host          hapipal:0
 
                 response headers
                 ────────────────────────────────────────
                  content-type      application/json; charset=utf-8
                  cache-control     no-cache
                  content-length    18
-                 connection        close
 
                 result (420 unknown)
                 ────────────────────────────────────────


### PR DESCRIPTION
The purpose of this PR is to support deeply set parameters in `hpal curl`.

For example, a payload such as `{"user":{"username":"pal"}}` may be specified (providing that joi validation is utilized) with the command,
```
hpal run debug:curl some-route --user-username pal
```

Also updates travis config for node 10.  This is marked as a bug because it fixes some undesirable behavior: an empty payload object would be sent with every request if no payload params were specified.  Now it omits the payload completely.